### PR TITLE
Fix for initial start up and not having access token

### DIFF
--- a/server/streams/fetchStreams.js
+++ b/server/streams/fetchStreams.js
@@ -59,6 +59,9 @@ const addVoid = async (client, stream) => {
 // returns json.pagination (new cursor)
 const fetchStreams = async (cursor, token) => {
   // set up call
+  if (!token) {
+      token = await refreshAccessToken();
+  }
   let options = {
     uri:
       'https://api.twitch.tv/helix/streams?first=100&language=en&after=' +


### PR DESCRIPTION
provides mechanism for start up without having to grab the accessToken up front
doesn't run otherwise